### PR TITLE
SAR-5980: Prefix 'Error' to the page title when a form has errors

### DIFF
--- a/app/utils/TitleHelper.scala
+++ b/app/utils/TitleHelper.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.data.Form
+import play.api.i18n.Messages
+
+object TitleHelper {
+
+  def title(titleMessage: String, form: Form[_])(implicit messages: Messages): String =
+    if (form.hasErrors) {
+      messages("error.titleError") + " " + titleMessage
+    }
+    else {
+      titleMessage
+    }
+
+}

--- a/app/views/atLeastOneDirectorHasNino.scala.html
+++ b/app/views/atLeastOneDirectorHasNino.scala.html
@@ -19,11 +19,12 @@
 @import controllers.routes._
 @import models.Mode
 @import utils.FormHelpers
+@import utils.TitleHelper.title
 
 @(appConfig: FrontendAppConfig, form: Form[_])(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("atLeastOneDirectorHasNino.title"),
+    title = title(messages("atLeastOneDirectorHasNino.title"), form),
     appConfig = appConfig,
     bodyClasses = None) {
 

--- a/app/views/offshoreEmployer.scala.html
+++ b/app/views/offshoreEmployer.scala.html
@@ -19,11 +19,12 @@
 @import controllers.routes._
 @import models.Mode
 @import utils.FormHelpers
+@import utils.TitleHelper.title
 
 @(appConfig: FrontendAppConfig, form: Form[_])(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("offshoreEmployer.title"),
+    title = title(messages("offshoreEmployer.title"), form),
     appConfig = appConfig,
     bodyClasses = None) {
 

--- a/app/views/taxedAwardScheme.scala.html
+++ b/app/views/taxedAwardScheme.scala.html
@@ -19,11 +19,12 @@
 @import controllers.routes._
 @import models.Mode
 @import utils.FormHelpers
+@import utils.TitleHelper.title
 
 @(appConfig: FrontendAppConfig, form: Form[_])(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = messages("taxedAwardScheme.title"),
+    title = title(messages("taxedAwardScheme.title"), form),
     appConfig = appConfig,
     bodyClasses = None) {
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -8,6 +8,7 @@ date.day                                            = Day
 date.month                                          = Month
 date.year                                           = Year
 
+error.titleError                                    = Error:
 error.boolean                                       = Please give an answer
 error.invalid_date                                  = Give a correct date
 error.date.day_blank                                = Enter a day

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -8,6 +8,7 @@ date.day                                            = Day
 date.month                                          = Month
 date.year                                           = Year
 
+error.titleError                                    = Error:
 error.boolean                                       = Please give an answer
 error.invalid_date                                  = Give a correct date
 error.date.day_blank                                = Enter a day

--- a/test/views/behaviours/YesNoViewBehaviours.scala
+++ b/test/views/behaviours/YesNoViewBehaviours.scala
@@ -61,15 +61,18 @@ trait YesNoViewBehaviours extends QuestionViewBehaviours[Boolean] {
       }
 
       "rendered with an error" must {
+        lazy val doc = asDocument(createView(form.withError(error)))
         "show an error summary" in {
-          val doc = asDocument(createView(form.withError(error)))
           assertRenderedById(doc, "error-summary-heading")
         }
 
         "show an error in the value field's label" in {
-          val doc = asDocument(createView(form.withError(error)))
           val errorSpan = doc.getElementsByClass("error-notification").first
           errorSpan.text mustBe messages(errorMessage)
+        }
+
+        "show an error prefix in the title" in {
+          doc.title must include(messages("error.titleError"))
         }
       }
     }


### PR DESCRIPTION
* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date
