### PR TITLE
[SAR-10785] Remove TODOs around WelshLangFS and refactor connectors

### DIFF
--- a/app/connectors/CompanyRegistrationConnector.scala
+++ b/app/connectors/CompanyRegistrationConnector.scala
@@ -18,43 +18,31 @@ package connectors
 
 
 import config.AppConfig
-import utils.Logging
-import play.api.libs.json._
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import connectors.httpParsers.CompanyRegistrationHttpParsers
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.PREFEFeatureSwitches
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CompanyRegistrationConnector @Inject()(val featureSwitch: PREFEFeatureSwitches,
                                              val http: HttpClient,
-                                             val appConfig: AppConfig) extends Logging {
+                                             val appConfig: AppConfig) extends CompanyRegistrationHttpParsers {
 
   lazy val companyRegistrationUrl: String = appConfig.config.baseUrl("company-registration")
   lazy val companyRegistrationUri: String = appConfig.config.getConfString("company-registration.uri", throw new Exception("company-registration.uri doesn't exist"))
   lazy val stubUrl: String = appConfig.config.baseUrl("incorporation-frontend-stubs")
   lazy val stubUri: String = appConfig.config.getConfString("incorporation-frontend-stubs.uri", throw new Exception("incorporation-frontend-stubs.uri doesn't exist"))
 
-  def getCompanyRegistrationStatusAndPaymentRef(regId: String)(implicit hc: HeaderCarrier): Future[(Option[String], Option[String])] = {
+  def getCompanyRegistrationStatusAndPaymentRef(regId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[(Option[String], Option[String])] = {
 
     val url = if (useCompanyRegistration) s"$companyRegistrationUrl$companyRegistrationUri/corporation-tax-registration" else s"$stubUrl$stubUri"
-    http.GET[JsObject](s"$url/$regId/corporation-tax-registration") map { response =>
-      val statusAndPaymentRef = for {
-        status <- (response \ "status").validate[String]
-        paymentRef <- (response \ "confirmationReferences" \ "payment-reference").validateOpt[String]
-      } yield (status, paymentRef)
 
-      statusAndPaymentRef.fold({ invalid =>
-        logger.error(s"[getCompanyRegistrationStatusAndPaymentRef] json returned from CR does not contain status, user will redirect to OTRS")
-        (None, None)
-      }, s => (Some(s._1), s._2))
-    } recover {
+    http.GET[(Option[String], Option[String])](s"$url/$regId/corporation-tax-registration")(companyRegistrationStatusAndPaymentRefHttpParser, hc, ec) recover {
       case ex =>
         logger.error(s"[getCompanyRegistrationStatusAndPaymentRef] ${ex.getMessage}")
-        (None, None)
+        None -> None
     }
   }
 

--- a/app/connectors/httpParsers/BusinessRegistrationHttpParsers.scala
+++ b/app/connectors/httpParsers/BusinessRegistrationHttpParsers.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import play.api.http.Status.{NOT_FOUND, OK}
+import play.api.libs.json.{Reads, __}
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.Logging
+
+trait BusinessRegistrationHttpParsers extends Logging {
+
+  val retrieveCurrentProfileHttpReads: HttpReads[Option[String]] = (_: String, _: String, response: HttpResponse) =>
+    response.status match {
+      case OK =>
+        val reads: Reads[String] = (__ \ "registrationID").read[String]
+        response.json.validate[String](reads).fold({ _ =>
+          logger.error(s"[retrieveCurrentProfileHttpReads] json returned from BR does not contain registrationID, user will redirect to OTRS")
+          None
+        }, s => Some(s))
+      case NOT_FOUND =>
+        None
+      case status =>
+        logger.error(s"[retrieveCurrentProfileHttpReads] status not 200, actually $status user directed to OTRS")
+        None
+    }
+}
+
+object BusinessRegistrationHttpParsers extends BusinessRegistrationHttpParsers

--- a/app/connectors/httpParsers/CompanyRegistrationHttpParsers.scala
+++ b/app/connectors/httpParsers/CompanyRegistrationHttpParsers.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import play.api.http.Status.{NOT_FOUND, OK}
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import utils.Logging
+
+trait CompanyRegistrationHttpParsers extends Logging {
+
+  val companyRegistrationStatusAndPaymentRefHttpParser: HttpReads[(Option[String], Option[String])] = (_: String, _: String, response: HttpResponse) => {
+    response.status match {
+      case OK =>
+        val statusAndPaymentRef = for {
+          status <- (response.json \ "status").validate[String]
+          paymentRef <- (response.json \ "confirmationReferences" \ "payment-reference").validateOpt[String]
+        } yield (status, paymentRef)
+
+        statusAndPaymentRef.fold({ _ =>
+          logger.error(s"[companyRegistrationStatusAndPaymentRefHttpParser] json returned from CR does not contain status, user will redirect to OTRS")
+          None -> None
+        }, s => Some(s._1) -> s._2)
+      case NOT_FOUND =>
+        None -> None
+      case status =>
+        logger.error(s"[companyRegistrationStatusAndPaymentRefHttpParser] status not 200, actually $status user directed to OTRS")
+        None -> None
+    }
+  }
+}
+
+object CompanyRegistrationHttpParsers extends CompanyRegistrationHttpParsers

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -35,7 +35,6 @@ class IndexController @Inject()(
   private val english = "english"
 
   def onPageLoad: Action[AnyContent] = Action { implicit request =>
-    //TODO Remove when Welsh FS is removed
     if ((languageUtils.getCurrentLang == welsh) && !appConfig.languageTranslationEnabled) {
       Redirect(controllers.routes.LanguageSwitchController.setLanguage(english))
     } else {

--- a/app/controllers/LanguageSwitchController.scala
+++ b/app/controllers/LanguageSwitchController.scala
@@ -32,7 +32,6 @@ class LanguageSwitchController @Inject()(appConfig: AppConfig,
 
   def languageMap: Map[String, Lang] = appConfig.languageMap
 
-  //TODO Remove when Welsh FS is removed
   def setLanguage(language: String): Action[AnyContent] = Action { implicit request =>
     val enabled: Boolean = languageMap.get(language).exists(languageUtils.isLangAvailable)
     val lang: Lang =

--- a/app/views/templates/error_template.scala.html
+++ b/app/views/templates/error_template.scala.html
@@ -16,7 +16,6 @@
 
 @import config.AppConfig
 @import views.html.components.{h1, p}
-@import views.html.templates.layout
 
 @this(layout: layout, h1: h1, p: p)
 

--- a/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
+++ b/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
@@ -30,23 +30,24 @@ import scala.concurrent.Future
 
 class BusinessRegistrationHttpParsersSpec extends SpecBase with Eventually with LogCapturingHelper {
 
-  "calling .retrieveCurrentProfileHttpReads" should {
-    val BusRegJson = Json.parse(
-      s"""
-         |{
-         | "registrationID" : "regId",
-         | "language" : "ENG",
-         | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
-         |}
+  val BusRegJson = Json.parse(
+    s"""
+       |{
+       | "registrationID" : "regId",
+       | "language" : "ENG",
+       | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
+       |}
       """.stripMargin)
 
-    val BusRegJsonNoRegId = Json.parse(
-      s"""
-         |{
-         | "language" : "ENG",
-         | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
-         |}
+  val BusRegJsonNoRegId = Json.parse(
+    s"""
+       |{
+       | "language" : "ENG",
+       | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
+       |}
       """.stripMargin)
+
+  "calling .retrieveCurrentProfileHttpReads" should {
 
     "return Some(regid) when OK is returned with valid JSON" in {
 

--- a/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
+++ b/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import base.SpecBase
+import ch.qos.logback.classic.Level
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.concurrent.Eventually
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.{HttpClient, _}
+import utils.LogCapturingHelper
+
+import scala.concurrent.Future
+
+class BusinessRegistrationHttpParsersSpec extends SpecBase with Eventually with LogCapturingHelper {
+
+  "calling .retrieveCurrentProfileHttpReads" should {
+    val BusRegJson = Json.parse(
+      s"""
+         |{
+         | "registrationID" : "regId",
+         | "language" : "ENG",
+         | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
+         |}
+      """.stripMargin)
+
+    val BusRegJsonNoRegId = Json.parse(
+      s"""
+         |{
+         | "language" : "ENG",
+         | "formCreationTimestamp" : "2019-02-07T13:48:05Z"
+         |}
+      """.stripMargin)
+
+    "return Some(regid) when OK is returned with valid JSON" in {
+
+      val response = HttpResponse(OK, json = BusRegJson, Map())
+
+      BusinessRegistrationHttpParsers.retrieveCurrentProfileHttpReads.read("", "", response) mustBe Some("regId")
+    }
+
+    "return None when OK is returned but not registrationId exists (log an error)" in {
+
+      val response = HttpResponse(OK, json = BusRegJsonNoRegId, Map())
+
+      withCaptureOfLoggingFrom(BusinessRegistrationHttpParsers.logger) { logs =>
+        BusinessRegistrationHttpParsers.retrieveCurrentProfileHttpReads.read("", "", response) mustBe None
+        logs.containsMsg(Level.ERROR, "[BusinessRegistrationHttpParsers][retrieveCurrentProfileHttpReads] json returned from BR does not contain registrationID, user will redirect to OTRS")
+      }
+    }
+
+    "return None when NOT_FOUND is returned" in {
+
+      val response = HttpResponse(NOT_FOUND, "")
+      BusinessRegistrationHttpParsers.retrieveCurrentProfileHttpReads.read("", "", response) mustBe None
+    }
+
+    "return None when any other status is returned and log an error" in {
+
+      val response = HttpResponse(INTERNAL_SERVER_ERROR, "")
+
+      withCaptureOfLoggingFrom(BusinessRegistrationHttpParsers.logger) { logs =>
+        BusinessRegistrationHttpParsers.retrieveCurrentProfileHttpReads.read("", "", response) mustBe None
+        logs.containsMsg(Level.ERROR, s"[BusinessRegistrationHttpParsers][retrieveCurrentProfileHttpReads] status not 200, actually $INTERNAL_SERVER_ERROR user directed to OTRS")
+      }
+    }
+  }
+}

--- a/test/connectors/httpParsers/CompanyRegistrationHttpParsersSpec.scala
+++ b/test/connectors/httpParsers/CompanyRegistrationHttpParsersSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import base.SpecBase
+import ch.qos.logback.classic.Level
+import org.scalatest.concurrent.Eventually
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers._
+import uk.gov.hmrc.http._
+import utils.LogCapturingHelper
+
+class CompanyRegistrationHttpParsersSpec extends SpecBase with Eventually with LogCapturingHelper {
+
+  val status = "submitted"
+  val paytReference = "payt1234"
+
+  val profileJson: JsObject =
+    Json.parse(
+      s"""
+         |{
+         |    "registration-id" : "testRegId",
+         |    "status" : "$status"
+         |}
+      """.stripMargin).as[JsObject]
+
+  val profileWithPaymentRefJson: JsObject =
+    Json.parse(
+      s"""
+         |{
+         |    "registration-id" : "testRegId",
+         |    "status" : "$status",
+         |    "confirmationReferences" : {
+         |       "payment-reference" : "$paytReference"
+         |    }
+         |}
+      """.stripMargin).as[JsObject]
+
+  val profileJsonNoStatus: JsObject =
+    Json.parse(
+      s"""
+         |{
+         |    "registration-id" : "testRegId"
+         |}
+      """.stripMargin).as[JsObject]
+
+  "calling .companyRegistrationStatusAndPaymentRefHttpParser" should {
+
+    "return (Some(status), None) when OK is returned with valid JSON but only status is present" in {
+
+      val response = HttpResponse(OK, json = profileJson, Map())
+
+      CompanyRegistrationHttpParsers.companyRegistrationStatusAndPaymentRefHttpParser.read("", "", response) mustBe Some(status) -> None
+    }
+
+    "return (Some(status), Some(paytReference) when OK is returned with valid JSON with Payment Reference" in {
+
+      val response = HttpResponse(OK, json = profileWithPaymentRefJson, Map())
+
+      CompanyRegistrationHttpParsers.companyRegistrationStatusAndPaymentRefHttpParser.read("", "", response) mustBe Some(status) -> Some(paytReference)
+    }
+
+    "return (None, None) when OK is returned but no status exists (log an error)" in {
+
+      val response = HttpResponse(OK, json = profileJsonNoStatus, Map())
+
+      withCaptureOfLoggingFrom(CompanyRegistrationHttpParsers.logger) { logs =>
+        CompanyRegistrationHttpParsers.companyRegistrationStatusAndPaymentRefHttpParser.read("", "", response) mustBe None -> None
+        logs.containsMsg(Level.ERROR, "[CompanyRegistrationHttpParsers][companyRegistrationStatusAndPaymentRefHttpParser] json returned from CR does not contain status, user will redirect to OTRS")
+      }
+    }
+
+    "return None when NOT_FOUND is returned" in {
+
+      val response = HttpResponse(NOT_FOUND, "")
+      CompanyRegistrationHttpParsers.companyRegistrationStatusAndPaymentRefHttpParser.read("", "", response) mustBe None -> None
+    }
+
+    "return None when any other status is returned and log an error" in {
+
+      val response = HttpResponse(INTERNAL_SERVER_ERROR, "")
+
+      withCaptureOfLoggingFrom(CompanyRegistrationHttpParsers.logger) { logs =>
+        CompanyRegistrationHttpParsers.companyRegistrationStatusAndPaymentRefHttpParser.read("", "", response) mustBe None -> None
+        logs.containsMsg(Level.ERROR, s"[CompanyRegistrationHttpParsers][companyRegistrationStatusAndPaymentRefHttpParser] status not 200, actually $INTERNAL_SERVER_ERROR user directed to OTRS")
+      }
+    }
+  }
+}

--- a/test/controllers/RegisterForPayeControllerSpec.scala
+++ b/test/controllers/RegisterForPayeControllerSpec.scala
@@ -109,7 +109,7 @@ class RegisterForPayeControllerSpec extends ControllerSpecBase {
         .thenReturn(Future.successful(()))
       when(mockBusinessRegistrationConnector.retrieveCurrentProfile(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some("regid")))
-      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any()))
+      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful((Some("held"), Some("payment"))))
 
       val result = Controller.continueToPayeOrOTRS(fakeRequest())
@@ -122,7 +122,7 @@ class RegisterForPayeControllerSpec extends ControllerSpecBase {
         .thenReturn(Future.successful(()))
       when(mockBusinessRegistrationConnector.retrieveCurrentProfile(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some("regid")))
-      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any()))
+      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful((Option.empty[String], Option.empty[String])))
 
       val result = Controller.continueToPayeOrOTRS(fakeRequest())
@@ -135,7 +135,7 @@ class RegisterForPayeControllerSpec extends ControllerSpecBase {
         .thenReturn(Future.successful(()))
       when(mockBusinessRegistrationConnector.retrieveCurrentProfile(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some("regid")))
-      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any()))
+      when(mockCompanyRegistrationConnector.getCompanyRegistrationStatusAndPaymentRef(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful((Some("held"), Option.empty[String])))
 
       val result = Controller.continueToPayeOrOTRS(fakeRequest())

--- a/test/utils/LogCapturingHelper.scala
+++ b/test/utils/LogCapturingHelper.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import org.scalatest.Assertions.{fail, succeed}
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+trait LogCapturingHelper extends LogCapturing {
+
+  implicit class LogCapturingExtensions(logs: List[ILoggingEvent]) {
+    def containsMsg(level: Level, msg: String) =
+      logs.find(_.getMessage.contains(msg)) match {
+      case Some(log) => if(log.getLevel == level) succeed else fail(
+        s"Found a log with the correct message, but the Level was '${log.getLevel}' when expecting '$level'"
+      )
+      case None => fail(s"Could not find log with message that contains '$msg'. Actual logs recorded: \n - ${logs.map(_.getMessage).mkString("\n - ")}")
+    }
+  }
+
+}


### PR DESCRIPTION
Introduces custom HttpParsers to remove the use on the deprecated legacyReads from the HttpClient library